### PR TITLE
Add WebSocket ping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,31 @@
 version = 4
 
 [[package]]
+name = "actix"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7fa236829ba0841304542f7614c42b80fca007455315c45c785ccfa873a85b"
+dependencies = [
+ "actix-macros",
+ "actix-rt",
+ "actix_derive",
+ "bitflags",
+ "bytes",
+ "crossbeam-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,12 +199,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-actors"
+version = "4.3.1+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98c5300b38fd004fe7d2a964f9a90813fdbe8a81fed500587e78b1b71c6f980"
+dependencies = [
+ "actix",
+ "actix-codec",
+ "actix-http",
+ "actix-web",
+ "bytes",
+ "bytestring",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-web-codegen"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
 dependencies = [
  "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "actix_derive"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -349,6 +403,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,7 +497,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "finalApproach"
 version = "0.1.0"
 dependencies = [
+ "actix",
  "actix-web",
+ "actix-web-actors",
  "mime_guess",
  "rust-embed",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,7 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4"
+actix-web-actors = "4"
+actix = "0.13"
 rust-embed = "8"
 mime_guess = "2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
-use actix_web::{get, post, web, App, HttpResponse, HttpServer, Responder};
+use actix_web::{get, post, web, App, HttpRequest, HttpResponse, HttpServer, Responder, Error};
+use actix_web_actors::ws;
+use actix::prelude::*;
 use rust_embed::RustEmbed;
 use mime_guess::from_path;
 use std::env;
@@ -6,6 +8,36 @@ use std::env;
 #[derive(RustEmbed)]
 #[folder = "./ui/dist/ui/browser/"]
 struct Asset;
+
+struct MyWebSocket;
+
+impl Actor for MyWebSocket {
+    type Context = ws::WebsocketContext<Self>;
+}
+
+impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for MyWebSocket {
+    fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
+        match msg {
+            Ok(ws::Message::Text(text)) => {
+                if text == "ping" {
+                    ctx.text("pong");
+                } else {
+                    ctx.text(text);
+                }
+            }
+            Ok(ws::Message::Ping(msg)) => ctx.pong(&msg),
+            Ok(ws::Message::Close(reason)) => {
+                ctx.close(reason);
+                ctx.stop();
+            }
+            _ => {}
+        }
+    }
+}
+
+async fn ws_index(req: HttpRequest, stream: web::Payload) -> Result<HttpResponse, Error> {
+    ws::start(MyWebSocket {}, &req, stream)
+}
 
 #[get("/{filename:.*}")]
 async fn serve_file(path: web::Path<String>) -> impl Responder {
@@ -55,6 +87,7 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .service(ping)
             .service(post_data)
+            .route("/ws", web::get().to(ws_index))
             .service(serve_file)
     })
     .bind(bind_addr)?

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -12,6 +12,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MapService } from './services/map.service';
 import { ToastrService } from 'ngx-toastr';
 import { AppService } from './services/app.service';
+import { PingService } from './services/ping.service';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import {Fill, Stroke, Style, Text} from 'ol/style';
@@ -62,10 +63,14 @@ export class AppComponent implements OnInit {
     private dialog: MatDialog,
     private mapService: MapService,
     private appService: AppService,
-    private toastr: ToastrService
+    private toastr: ToastrService,
+    private pingService: PingService
   ) {}
 
   ngOnInit(): void {
+    this.pingService.ping().subscribe(response => {
+      console.log('Ping response:', response);
+    });
     this.osmLayer = new TileLayer({
           source: new OSM({
             attributions: []

--- a/ui/src/app/services/ping.service.ts
+++ b/ui/src/app/services/ping.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PingService {
+  constructor() {}
+
+  ping(): Observable<string> {
+    return new Observable(observer => {
+      const ws = new WebSocket(environment.wsUrl);
+
+      ws.onopen = () => {
+        ws.send('ping');
+      };
+
+      ws.onmessage = event => {
+        observer.next(event.data);
+        observer.complete();
+        ws.close();
+      };
+
+      ws.onerror = err => {
+        observer.error(err);
+      };
+    });
+  }
+}

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
   apiBaseUrl: '/api',
+  wsUrl: '/ws'
 };

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
   apiBaseUrl: 'http://localhost:8080/api',
+  wsUrl: 'ws://localhost:8080/ws'
 };


### PR DESCRIPTION
## Summary
- add WebSocket support on the server with a simple ping/pong actor
- expose a `/ws` route
- create an Angular `PingService` that talks to the websocket
- invoke ping on app start and log the response
- include websocket URL in environment files

## Testing
- `cargo check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e0061fab08325932e23ec0d21f9e3