### PR TITLE
Restore WebSocket endpoint

### DIFF
--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -1,0 +1,33 @@
+use actix::prelude::*;
+use actix_web::{HttpRequest, HttpResponse, Error, web};
+use actix_web_actors::ws;
+
+pub struct MyWebSocket;
+
+impl Actor for MyWebSocket {
+    type Context = ws::WebsocketContext<Self>;
+}
+
+impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for MyWebSocket {
+    fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
+        match msg {
+            Ok(ws::Message::Text(text)) => {
+                if text == "ping" {
+                    ctx.text("pong");
+                } else {
+                    ctx.text(text);
+                }
+            }
+            Ok(ws::Message::Ping(msg)) => ctx.pong(&msg),
+            Ok(ws::Message::Close(reason)) => {
+                ctx.close(reason);
+                ctx.stop();
+            }
+            _ => {}
+        }
+    }
+}
+
+pub async fn ws_index(req: HttpRequest, stream: web::Payload) -> Result<HttpResponse, Error> {
+    ws::start(MyWebSocket {}, &req, stream)
+}


### PR DESCRIPTION
## Summary
- Re-introduce WebSocket support via dedicated `websocket` module
- Register `/ws` route using new handler

## Testing
- `cargo test`
- `npm --prefix ui test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6893c0907f9883259d724375f2f5ccca